### PR TITLE
Add support for columns with server_default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
 
@@ -27,7 +27,7 @@ repos:
         args: ["--py38-plus"]
 
   - repo: https://github.com/PyCQA/autoflake.git
-    rev: v2.0.0
+    rev: v2.0.1
     hooks:
       - id: autoflake
         args:
@@ -37,17 +37,17 @@ repos:
           - --expand-star-imports
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.1
     hooks:
       - id: mypy
 
   - repo: https://github.com/PyCQA/isort
-    rev: v5.11.3
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ def downgrade():
 
 Under the hood, the `EnumMigration` class creates a new enum type, updates the target columns to use the new enum type, and deletes the old enum type.
 
+
+## Change column default values
+
+If you need to change the column default values while changing the enum type, you can pass an optional server_default argument to the Column constructor. The constructor has to be a `Change()` with `old` and `new` arguments. For example:
+
+
+```python
+from alembic_enums import Change, Column
+
+column = Column(
+    "resources",
+    "state",
+    server_default=Change(old="enabled", new="active"),
+)
+```
+
+The default value of `server_default` is `Keep()`, which means that the server_default value will be kept as is.
+
+
 ## API reference
 
 ### `EnumMigration`
@@ -103,3 +122,17 @@ A data class to define a target column for an enum migration.
 
 - `table_name`: the name of the table
 - `column_name`: the name of the column
+- `server_default`: the object that defines the server_default migration. Allowed values are `alembic_enums.Keep()`and `alembic_enums.Change(old, new)`. The default value is `alembic_enums.Keep()`.
+
+### `Keep`
+
+A sentinel object to keep the server_default value as is.
+
+### `Change`
+
+A configuration object to change the server_default value.
+
+**Constructor arguments:**
+
+- `old`: the old server_default value. When set to none, the server_default value is removed on downgrade.
+- `new`: the new server_default value. When set to None, the server_default value is removed on upgrade.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ from alembic_enums import EnumMigration, Column
 
 # Define a target column. As in PostgreSQL, the same enum can be used in multiple
 # column definitions, you may have more than one target column.
-column = Column("resources", "state")
+# The constructor arguments are the table name, the column name, and the
+# server_default values for the old and new enum types.
+column = Column("resources", "state", old_server_default=None, new_server_default=None)
 
 # Define an enum migration. It defines the old and new enum values
 # for the enum, and the list of target columns.
@@ -76,21 +78,24 @@ Under the hood, the `EnumMigration` class creates a new enum type, updates the t
 
 ## Change column default values
 
-If you need to change the column default values while changing the enum type, you can pass an optional server_default argument to the Column constructor. The constructor has to be a `Change()` with `old` and `new` arguments. For example:
+
+To change the column default values, pass corresponding values to new_server_default and old_server_default arguments of the Column constructor. The new_server_default is used on upgrade, and the old_server_default is used on downgrade.
+
+IMPORTANT: Setting the server_default value to None will remove the default value from the column. If you want to keep the default value as is, set old_server_default and new_server_default to the same value.
+
+For example, to change the default value of the `state` column from `enabled` to `active`:
 
 
 ```python
-from alembic_enums import Change, Column
+from alembic_enums import Column
 
 column = Column(
     "resources",
     "state",
-    server_default=Change(old="enabled", new="active"),
+    old_server_default="enabled",
+    new_server_default="active",
 )
 ```
-
-The default value of `server_default` is `Keep()`, which means that the server_default value will be kept as is.
-
 
 ## API reference
 
@@ -122,17 +127,5 @@ A data class to define a target column for an enum migration.
 
 - `table_name`: the name of the table
 - `column_name`: the name of the column
-- `server_default`: the object that defines the server_default migration. Allowed values are `alembic_enums.Keep()`and `alembic_enums.Change(old, new)`. The default value is `alembic_enums.Keep()`.
-
-### `Keep`
-
-A sentinel object to keep the server_default value as is.
-
-### `Change`
-
-A configuration object to change the server_default value.
-
-**Constructor arguments:**
-
-- `old`: the old server_default value. When set to none, the server_default value is removed on downgrade.
-- `new`: the new server_default value. When set to None, the server_default value is removed on upgrade.
+- `old_server_default`: the old server_default value. When set to None, the server_default value is removed on downgrade.
+- `new_server_default`: the new server_default value. When set to None, the server_default value is removed on upgrade.

--- a/alembic_enums/__init__.py
+++ b/alembic_enums/__init__.py
@@ -1,3 +1,3 @@
-from alembic_enums.enum_migration import Change, Column, EnumMigration, Keep
+from alembic_enums.enum_migration import Column, EnumMigration
 
-__all__ = ["EnumMigration", "Column", "Change", "Keep"]
+__all__ = ["EnumMigration", "Column"]

--- a/alembic_enums/__init__.py
+++ b/alembic_enums/__init__.py
@@ -1,3 +1,3 @@
-from alembic_enums.enum_migration import Column, EnumMigration
+from alembic_enums.enum_migration import Change, Column, EnumMigration, Keep
 
-__all__ = ["EnumMigration", "Column"]
+__all__ = ["EnumMigration", "Column", "Change", "Keep"]

--- a/alembic_enums/enum_migration.py
+++ b/alembic_enums/enum_migration.py
@@ -1,16 +1,49 @@
 import random
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import List, Optional
+from enum import Enum
+from typing import List, Optional, Union
 
 import sqlalchemy as sa
 from alembic.operations import Operations
 
 
+class OperationType(Enum):
+    UPGRADE = "upgrade"
+    DOWNGRADE = "downgrade"
+
+
+class Keep:
+    """A sentinel value that indicates that the server default should not be changed."""
+
+
+@dataclass
+class Change:
+    """A configuration object that defines a server default change."""
+
+    old: Optional[str]
+    new: Optional[str]
+
+
 @dataclass
 class Column:
+    """A column that contains an enum.
+
+    The table and name parameters define the coordinates of the column. The
+    server_default option defines the server default upgrade and downgrade operations.
+
+    The default value of server_default is Keep(). This means that the server default
+    will not be changed.
+
+    If you want to change the server default, you can pass a Change object. E.g.,
+    Change(old="on", new="off") will change the server default from "on" to "off".
+
+    Passing None as the new value will remove the server default on upgrade.
+    """
+
     table: str
     name: str
+    server_default: Union[Keep, Change] = Keep()
 
 
 class EnumMigration:
@@ -29,7 +62,8 @@ class EnumMigration:
             old_options: The old options for the enum.
             new_options: The new options for the enum.
             enum_name: The name of the enum.
-            columns: The columns that contain the enum.
+            columns: The columns that contain the enum with optional upgrade and
+                downgrade server default operations.
         """
         self.op = op
 
@@ -48,17 +82,23 @@ class EnumMigration:
         self.columns = columns or []
 
     def upgrade_ctx(self):
-        return self._upgrade_or_downgrade_ctx(self.old_type, self.new_type)
+        return self._upgrade_or_downgrade_ctx(
+            self.old_type, self.new_type, OperationType.UPGRADE
+        )
 
     def upgrade(self):
         with self.upgrade_ctx():
             pass
 
     def downgrade_ctx(self):
-        return self._upgrade_or_downgrade_ctx(self.new_type, self.old_type)
+        return self._upgrade_or_downgrade_ctx(
+            self.new_type, self.old_type, OperationType.DOWNGRADE
+        )
 
     @contextmanager
-    def _upgrade_or_downgrade_ctx(self, from_: sa.Enum, to: sa.Enum):
+    def _upgrade_or_downgrade_ctx(
+        self, from_: sa.Enum, to: sa.Enum, operation_type: OperationType
+    ):
         self.temp_type.create(self.op.get_bind(), checkfirst=False)
         self._adjust_columns_to_temp_type()
 
@@ -66,7 +106,7 @@ class EnumMigration:
 
         from_.drop(self.op.get_bind(), checkfirst=False)
         to.create(self.op.get_bind(), checkfirst=False)
-        self._adjust_columns_to_target_type()
+        self._adjust_columns_to_target_type(operation_type)
         self.temp_type.drop(self.op.get_bind(), checkfirst=False)
 
     def downgrade(self):
@@ -87,19 +127,35 @@ class EnumMigration:
             self._adjust_column_to_temp_type(column)
 
     def _adjust_column_to_temp_type(self, column: Column):
+        if isinstance(column.server_default, Change):
+            self.op.execute(
+                f"ALTER TABLE {column.table} ALTER COLUMN {column.name} DROP DEFAULT"
+            )
         self.op.execute(
             f"ALTER TABLE {column.table} ALTER COLUMN {column.name} "
             f"TYPE {self.temp_enum_name} "
             f" USING {column.name}::text::{self.temp_enum_name}"
         )
 
-    def _adjust_columns_to_target_type(self):
+    def _adjust_columns_to_target_type(self, operation_type: OperationType):
         for column in self.columns:
-            self._adjust_column_to_target_type(column)
+            self._adjust_column_to_target_type(column, operation_type)
 
-    def _adjust_column_to_target_type(self, column: Column):
+    def _adjust_column_to_target_type(
+        self, column: Column, operation_type: OperationType
+    ):
         self.op.execute(
             f"ALTER TABLE {column.table} ALTER COLUMN {column.name} "
             f"TYPE {self.enum_name} "
             f"USING {column.name}::text::{self.enum_name}"
         )
+        if isinstance(column.server_default, Change):
+            if operation_type == OperationType.UPGRADE:
+                default = column.server_default.new
+            else:
+                default = column.server_default.old
+            if default is not None:
+                self.op.execute(
+                    f"ALTER TABLE {column.table} ALTER COLUMN {column.name} "
+                    f"SET DEFAULT {self.op.inline_literal(default)}"
+                )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,3 +30,16 @@ def database(engine):
     create_database(engine.url)
     yield
     drop_database(engine.url)
+
+
+@pytest.fixture
+def metadata():
+    return sa.MetaData()
+
+
+@pytest.fixture
+def state_enum(op):
+    enum = sa.Enum("on", "off", name="state_enum")
+    enum.create(op.get_bind(), checkfirst=True)
+    yield enum
+    enum.drop(op.get_bind(), checkfirst=True)

--- a/tests/test_enum_migration.py
+++ b/tests/test_enum_migration.py
@@ -1,8 +1,8 @@
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.exc import DataError
+from sqlalchemy.exc import DataError, IntegrityError
 
-from alembic_enums.enum_migration import Column, EnumMigration
+from alembic_enums import Change, Column, EnumMigration
 
 
 @pytest.fixture
@@ -24,6 +24,18 @@ def resources_table(op, metadata, state_enum):
         "resources",
         metadata,
         sa.Column("state", state_enum, nullable=False),
+    )
+    table.create(op.get_bind(), checkfirst=True)
+    yield table
+    table.drop(op.get_bind(), checkfirst=True)
+
+
+@pytest.fixture
+def resources_table_with_server_default(op, metadata, state_enum):
+    table = sa.Table(
+        "resources",
+        metadata,
+        sa.Column("state", state_enum, nullable=False, server_default="on"),
     )
     table.create(op.get_bind(), checkfirst=True)
     yield table
@@ -69,6 +81,85 @@ def test_downgrade_should_roll_back_changes(op, resources_table):
     migration.upgrade()
     migration.downgrade()
     op.bulk_insert(resources_table, [{"state": "on"}, {"state": "off"}])
+
+
+def test_upgrade_should_update_server_default(op, resources_table_with_server_default):
+    migration = EnumMigration(
+        op=op,
+        enum_name="state_enum",
+        old_options=["on", "off"],
+        new_options=["enabled", "disabled"],
+        columns=[
+            Column(
+                "resources",
+                "state",
+                server_default=Change(old="on", new="enabled"),
+            )
+        ],
+    )
+    migration.upgrade()
+    op.bulk_insert(resources_table_with_server_default, [{}])
+
+
+def test_downgrade_should_roll_back_server_default_changes(
+    op, resources_table_with_server_default
+):
+    migration = EnumMigration(
+        op=op,
+        enum_name="state_enum",
+        old_options=["on", "off"],
+        new_options=["enabled", "disabled"],
+        columns=[
+            Column(
+                "resources",
+                "state",
+                server_default=Change(old="on", new="enabled"),
+            )
+        ],
+    )
+    migration.upgrade()
+    migration.downgrade()
+    op.bulk_insert(resources_table_with_server_default, [{}])
+
+
+def test_upgrade_should_drop_server_default(op, resources_table_with_server_default):
+    migration = EnumMigration(
+        op=op,
+        enum_name="state_enum",
+        old_options=["on", "off"],
+        new_options=["enabled", "disabled"],
+        columns=[
+            Column(
+                "resources",
+                "state",
+                server_default=Change(old="on", new=None),
+            )
+        ],
+    )
+    migration.upgrade()
+    with pytest.raises(IntegrityError):
+        op.bulk_insert(resources_table_with_server_default, [{}])
+
+
+def test_downgrade_should_roll_back_server_default_drop(
+    op, resources_table_with_server_default
+):
+    migration = EnumMigration(
+        op=op,
+        enum_name="state_enum",
+        old_options=["on", "off"],
+        new_options=["enabled", "disabled"],
+        columns=[
+            Column(
+                "resources",
+                "state",
+                server_default=Change(old="on", new=None),
+            )
+        ],
+    )
+    migration.upgrade()
+    migration.downgrade()
+    op.bulk_insert(resources_table_with_server_default, [{}])
 
 
 def test_upgrade_context_should_allow_update_values(op, resources_table):

--- a/tests/test_enum_migration.py
+++ b/tests/test_enum_migration.py
@@ -25,7 +25,11 @@ def test_upgrade_should_extend_options(op, resources_table):
         enum_name="state_enum",
         old_options=["on", "off"],
         new_options=["on", "off", "unknown"],
-        columns=[Column("resources", "state")],
+        columns=[
+            Column(
+                "resources", "state", old_server_default=None, new_server_default=None
+            )
+        ],
     )
     migration.upgrade()
     op.bulk_insert(
@@ -39,7 +43,11 @@ def test_upgrade_should_replace_options(op, resources_table):
         enum_name="state_enum",
         old_options=["on", "off"],
         new_options=["enabled", "disabled"],
-        columns=[Column("resources", "state")],
+        columns=[
+            Column(
+                "resources", "state", old_server_default=None, new_server_default=None
+            )
+        ],
     )
     migration.upgrade()
     op.bulk_insert(resources_table, [{"state": "enabled"}, {"state": "disabled"}])
@@ -51,7 +59,11 @@ def test_downgrade_should_roll_back_changes(op, resources_table):
         enum_name="state_enum",
         old_options=["on", "off"],
         new_options=["enabled", "disabled"],
-        columns=[Column("resources", "state")],
+        columns=[
+            Column(
+                "resources", "state", old_server_default=None, new_server_default=None
+            )
+        ],
     )
     migration.upgrade()
     migration.downgrade()
@@ -60,7 +72,9 @@ def test_downgrade_should_roll_back_changes(op, resources_table):
 
 def test_upgrade_context_should_allow_update_values(op, resources_table):
     op.bulk_insert(resources_table, [{"state": "on"}, {"state": "off"}])
-    column = Column("resources", "state")
+    column = Column(
+        "resources", "state", old_server_default=None, new_server_default=None
+    )
     migration = EnumMigration(
         op=op,
         enum_name="state_enum",
@@ -75,7 +89,9 @@ def test_upgrade_context_should_allow_update_values(op, resources_table):
 
 
 def test_downgrade_context_should_allow_update_values(op, resources_table):
-    column = Column("resources", "state")
+    column = Column(
+        "resources", "state", old_server_default=None, new_server_default=None
+    )
     migration = EnumMigration(
         op=op,
         enum_name="state_enum",

--- a/tests/test_enum_migration.py
+++ b/tests/test_enum_migration.py
@@ -1,21 +1,8 @@
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.exc import DataError, IntegrityError
+from sqlalchemy.exc import DataError
 
-from alembic_enums import Change, Column, EnumMigration
-
-
-@pytest.fixture
-def metadata():
-    return sa.MetaData()
-
-
-@pytest.fixture
-def state_enum(op):
-    enum = sa.Enum("on", "off", name="state_enum")
-    enum.create(op.get_bind(), checkfirst=True)
-    yield enum
-    enum.drop(op.get_bind(), checkfirst=True)
+from alembic_enums import Column, EnumMigration
 
 
 @pytest.fixture
@@ -24,18 +11,6 @@ def resources_table(op, metadata, state_enum):
         "resources",
         metadata,
         sa.Column("state", state_enum, nullable=False),
-    )
-    table.create(op.get_bind(), checkfirst=True)
-    yield table
-    table.drop(op.get_bind(), checkfirst=True)
-
-
-@pytest.fixture
-def resources_table_with_server_default(op, metadata, state_enum):
-    table = sa.Table(
-        "resources",
-        metadata,
-        sa.Column("state", state_enum, nullable=False, server_default="on"),
     )
     table.create(op.get_bind(), checkfirst=True)
     yield table
@@ -81,85 +56,6 @@ def test_downgrade_should_roll_back_changes(op, resources_table):
     migration.upgrade()
     migration.downgrade()
     op.bulk_insert(resources_table, [{"state": "on"}, {"state": "off"}])
-
-
-def test_upgrade_should_update_server_default(op, resources_table_with_server_default):
-    migration = EnumMigration(
-        op=op,
-        enum_name="state_enum",
-        old_options=["on", "off"],
-        new_options=["enabled", "disabled"],
-        columns=[
-            Column(
-                "resources",
-                "state",
-                server_default=Change(old="on", new="enabled"),
-            )
-        ],
-    )
-    migration.upgrade()
-    op.bulk_insert(resources_table_with_server_default, [{}])
-
-
-def test_downgrade_should_roll_back_server_default_changes(
-    op, resources_table_with_server_default
-):
-    migration = EnumMigration(
-        op=op,
-        enum_name="state_enum",
-        old_options=["on", "off"],
-        new_options=["enabled", "disabled"],
-        columns=[
-            Column(
-                "resources",
-                "state",
-                server_default=Change(old="on", new="enabled"),
-            )
-        ],
-    )
-    migration.upgrade()
-    migration.downgrade()
-    op.bulk_insert(resources_table_with_server_default, [{}])
-
-
-def test_upgrade_should_drop_server_default(op, resources_table_with_server_default):
-    migration = EnumMigration(
-        op=op,
-        enum_name="state_enum",
-        old_options=["on", "off"],
-        new_options=["enabled", "disabled"],
-        columns=[
-            Column(
-                "resources",
-                "state",
-                server_default=Change(old="on", new=None),
-            )
-        ],
-    )
-    migration.upgrade()
-    with pytest.raises(IntegrityError):
-        op.bulk_insert(resources_table_with_server_default, [{}])
-
-
-def test_downgrade_should_roll_back_server_default_drop(
-    op, resources_table_with_server_default
-):
-    migration = EnumMigration(
-        op=op,
-        enum_name="state_enum",
-        old_options=["on", "off"],
-        new_options=["enabled", "disabled"],
-        columns=[
-            Column(
-                "resources",
-                "state",
-                server_default=Change(old="on", new=None),
-            )
-        ],
-    )
-    migration.upgrade()
-    migration.downgrade()
-    op.bulk_insert(resources_table_with_server_default, [{}])
 
 
 def test_upgrade_context_should_allow_update_values(op, resources_table):

--- a/tests/test_server_default.py
+++ b/tests/test_server_default.py
@@ -2,7 +2,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 
-from alembic_enums import Change, Column, EnumMigration
+from alembic_enums import Column, EnumMigration
 
 
 @pytest.fixture
@@ -27,7 +27,24 @@ def test_upgrade_should_update_server_default(op, resources_table_with_server_de
             Column(
                 "resources",
                 "state",
-                server_default=Change(old="on", new="enabled"),
+                old_server_default="on",
+                new_server_default="enabled",
+            )
+        ],
+    )
+    migration.upgrade()
+    op.bulk_insert(resources_table_with_server_default, [{}])
+
+
+def test_upgrade_with_keep_should_succeed(op, resources_table_with_server_default):
+    migration = EnumMigration(
+        op=op,
+        enum_name="state_enum",
+        old_options=["on", "off"],
+        new_options=["on", "off", "unknown"],
+        columns=[
+            Column(
+                "resources", "state", old_server_default="on", new_server_default="on"
             )
         ],
     )
@@ -47,7 +64,8 @@ def test_downgrade_should_roll_back_server_default_changes(
             Column(
                 "resources",
                 "state",
-                server_default=Change(old="on", new="enabled"),
+                old_server_default="on",
+                new_server_default="enabled",
             )
         ],
     )
@@ -66,7 +84,8 @@ def test_upgrade_should_drop_server_default(op, resources_table_with_server_defa
             Column(
                 "resources",
                 "state",
-                server_default=Change(old="on", new=None),
+                old_server_default="on",
+                new_server_default=None,
             )
         ],
     )
@@ -87,7 +106,8 @@ def test_downgrade_should_roll_back_server_default_drop(
             Column(
                 "resources",
                 "state",
-                server_default=Change(old="on", new=None),
+                old_server_default="on",
+                new_server_default=None,
             )
         ],
     )

--- a/tests/test_server_default.py
+++ b/tests/test_server_default.py
@@ -1,0 +1,96 @@
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+
+from alembic_enums import Change, Column, EnumMigration
+
+
+@pytest.fixture
+def resources_table_with_server_default(op, metadata, state_enum):
+    table = sa.Table(
+        "resources",
+        metadata,
+        sa.Column("state", state_enum, nullable=False, server_default="on"),
+    )
+    table.create(op.get_bind(), checkfirst=True)
+    yield table
+    table.drop(op.get_bind(), checkfirst=True)
+
+
+def test_upgrade_should_update_server_default(op, resources_table_with_server_default):
+    migration = EnumMigration(
+        op=op,
+        enum_name="state_enum",
+        old_options=["on", "off"],
+        new_options=["enabled", "disabled"],
+        columns=[
+            Column(
+                "resources",
+                "state",
+                server_default=Change(old="on", new="enabled"),
+            )
+        ],
+    )
+    migration.upgrade()
+    op.bulk_insert(resources_table_with_server_default, [{}])
+
+
+def test_downgrade_should_roll_back_server_default_changes(
+    op, resources_table_with_server_default
+):
+    migration = EnumMigration(
+        op=op,
+        enum_name="state_enum",
+        old_options=["on", "off"],
+        new_options=["enabled", "disabled"],
+        columns=[
+            Column(
+                "resources",
+                "state",
+                server_default=Change(old="on", new="enabled"),
+            )
+        ],
+    )
+    migration.upgrade()
+    migration.downgrade()
+    op.bulk_insert(resources_table_with_server_default, [{}])
+
+
+def test_upgrade_should_drop_server_default(op, resources_table_with_server_default):
+    migration = EnumMigration(
+        op=op,
+        enum_name="state_enum",
+        old_options=["on", "off"],
+        new_options=["enabled", "disabled"],
+        columns=[
+            Column(
+                "resources",
+                "state",
+                server_default=Change(old="on", new=None),
+            )
+        ],
+    )
+    migration.upgrade()
+    with pytest.raises(IntegrityError):
+        op.bulk_insert(resources_table_with_server_default, [{}])
+
+
+def test_downgrade_should_roll_back_server_default_drop(
+    op, resources_table_with_server_default
+):
+    migration = EnumMigration(
+        op=op,
+        enum_name="state_enum",
+        old_options=["on", "off"],
+        new_options=["enabled", "disabled"],
+        columns=[
+            Column(
+                "resources",
+                "state",
+                server_default=Change(old="on", new=None),
+            )
+        ],
+    )
+    migration.upgrade()
+    migration.downgrade()
+    op.bulk_insert(resources_table_with_server_default, [{}])


### PR DESCRIPTION
Extend the Column class to support server_default values. The server_default value can be a Change object, which defines the old and new server_default values. The default value of server_default is Keep(), which means that the server_default value will be kept as is.

Ref: #2