### PR TITLE
support camel case column, table, and enum names

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,3 +43,11 @@ def state_enum(op):
     enum.create(op.get_bind(), checkfirst=True)
     yield enum
     enum.drop(op.get_bind(), checkfirst=True)
+
+
+@pytest.fixture
+def state_enum_with_camel_case(op):
+    enum = sa.Enum("onState", "offState", name="stateEnum")
+    enum.create(op.get_bind(), checkfirst=True)
+    yield enum
+    enum.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
Current version fails when there are upper case letters in column, table, or enum names.
This PR addresses such cases.
