### PR TITLE
Set Column *_server_default to None by default

### DIFF
--- a/alembic_enums/enum_migration.py
+++ b/alembic_enums/enum_migration.py
@@ -36,8 +36,8 @@ class Column:
 
     table: str
     name: str
-    old_server_default: Optional[str]
-    new_server_default: Optional[str]
+    old_server_default: Optional[str] = None
+    new_server_default: Optional[str] = None
 
 
 class EnumMigration:


### PR DESCRIPTION
Very simple PR to default the `*_server_default` to `None` as it is verbose and is not necessary in most cases.